### PR TITLE
Fix errors when compiling with -Wpedantic -std=c++11

### DIFF
--- a/egs_brachy/eb_volcor.cpp
+++ b/egs_brachy/eb_volcor.cpp
@@ -191,7 +191,7 @@ void Options::setDensity() {
     int err = input->getInput("density of random points (cm^-3)", density);
     if (err) {
         egsWarning("The volume correction 'density of random points (cm^-3)' input was not found\n");
-        density =  DEFAULT_RAND_POINT_DENSITY;
+        density =  (EGS_Float)DEFAULT_RAND_POINT_DENSITY;
     }
 
     npoints = floor(max(1., density*bounds_volume));

--- a/egs_brachy/eb_volcor.h
+++ b/egs_brachy/eb_volcor.h
@@ -137,7 +137,7 @@ typedef std::map<PhantRegT, EGS_I64> HitCounterT;
  * */
 class Options {
 
-    const static double DEFAULT_RAND_POINT_DENSITY = 1E8;
+    const static unsigned long DEFAULT_RAND_POINT_DENSITY = 100000000;
 
     EGS_Input *input;
 

--- a/egs_brachy/phantom.cpp
+++ b/egs_brachy/phantom.cpp
@@ -276,12 +276,12 @@ EGS_Float EB_Phantom::getUncorrectedVolume(int ireg) {
     // EGS_BaseGeometry::getMass is volume*relativeRho()
     EGS_Float volume = geometry->getMass(ireg)/geometry->getRelativeRho(ireg);
     return volume;
-};
+}
 
 EGS_Float EB_Phantom::getCorrectedVolume(int ireg) {
     bool has_correction = corrected_volumes.find(ireg) != corrected_volumes.end();
     return has_correction ? corrected_volumes[ireg] : getUncorrectedVolume(ireg);
-};
+}
 
 
 void EB_Phantom::getCurrentScore(int ireg, double &sum, double &sum2) {

--- a/egs_brachy/phsp.cpp
+++ b/egs_brachy/phsp.cpp
@@ -97,7 +97,7 @@ PHSPControl::PHSPControl(EGS_Input *inp, EGS_AffineTransform *trans, EGS_Advance
     initSource();
 
     pub->subscribe(this, PARTICLE_ESCAPED_SOURCE);
-};
+}
 
 
 short PHSPControl::getIAEAParticleType(const EGS_Particle *p) {

--- a/egs_brachy/pubsub.h
+++ b/egs_brachy/pubsub.h
@@ -62,7 +62,7 @@ enum EB_Message {
     PARTICLE_ESCAPING_GEOM,
     PARTICLE_ESCAPED_GEOM,
     PHOTON_SCATTER_EVENT, // scatter occuring anywhere
-    NON_SOURCE_PHOTON_SCATTER_EVENT, // scatter occuring outside source
+    NON_SOURCE_PHOTON_SCATTER_EVENT // scatter occuring outside source
 
 };
 

--- a/egs_brachy/spec_scoring.cpp
+++ b/egs_brachy/spec_scoring.cpp
@@ -248,7 +248,7 @@ string BaseSpectrumScorer::outputCSV(string rootname) {
 
     out.close();
     return fname;
-};
+}
 
 string BaseSpectrumScorer::outputEGSnrc(string rootname) {
 
@@ -301,7 +301,7 @@ string BaseSpectrumScorer::outputEGSnrc(string rootname) {
     out.close();
 
     return fname;
-};
+}
 
 string BaseSpectrumScorer::outputXMGR(string rootname) {
 
@@ -358,7 +358,7 @@ string BaseSpectrumScorer::outputXMGR(string rootname) {
 
     out.close();
     return fname;
-};
+}
 
 void BaseSpectrumScorer::update(EB_Message message, void *data) {
 
@@ -441,7 +441,7 @@ void SurfaceCountSpectrum::score(EB_Message message, void *data) {
         EGS_Particle *p= static_cast<EGS_Particle *>(data);
 
         double energy = getParticleEnergy(p);
-        
+
         if (e_min <= energy && energy <= e_max && p->q == particle_type) {
             bins->score(getBin(energy), 1.);
             total_scored += 1.;


### PR DESCRIPTION
The in class initializer of DEFAULT_RAND_POINT_DENSITY causes
problems for some compilers.

Resolves #1 