### PR TITLE
Remove particle weight (p.wt) override after getNextParticle() call

### DIFF
--- a/egs_brachy/egs_brachy.cpp
+++ b/egs_brachy/egs_brachy.cpp
@@ -1801,7 +1801,7 @@ int EB_Application::simulateSingleShower() {
         initial_source = 0;
     }
 
-    p.wt = source_weights[active_source];
+    p.wt *= source_weights[active_source];
 
     if (run_mode == RM_SUPERPOSITION) {
         superpos_geom->setActiveByIndex(initial_source);


### PR DESCRIPTION
Rather than replacing the weight of a particle by the source weight, the code should now multiply the source weight by the particle weight after a new particle is generated.  Thus, sources which return new particles with weights which are not unity (such as egs_collimated_source) should now work in egs_brachy.