### PR TITLE
Fix #33 Output total radiant energy

### DIFF
--- a/egs_brachy/phantom.cpp
+++ b/egs_brachy/phantom.cpp
@@ -520,6 +520,7 @@ void EB_Phantom::outputDoseStats(EGS_ScoringArray *score, string type) {
     string units = "Gy/hist";
     if (type == "pr" || type == "ss" || type == "ms" || type == "to") {
         units = "Gy/R";
+        egsInformation("\n    Total radiant energy                          =  %.3G MeV\n", total_radiant_e);
     }
 
     egsInformation("\n    Dose Scaling                                  =  %.3G\n", dose_scale);


### PR DESCRIPTION
Output total radiant energy in egslog when scoring scatter dose.