### PR TITLE
Allow transformed XYZ geometries

### DIFF
--- a/egs_brachy/egs_brachy.cpp
+++ b/egs_brachy/egs_brachy.cpp
@@ -216,6 +216,10 @@ void EB_Application::describeSimulation() {
             );
         }
 
+	if (type == "EGS_XYZGeometryT") {
+            egsWarning("\n***WARNING***\nPhantom of type transformed XYZ geometry used. The bounds of the phantom reported in the egslog, 3ddose, and egsphant files will be incorrect due to limitations of the geometry library.\n***WARNING***\n");
+        }
+
     }
 
     egsInformation("\n\negs_brachy Volume correction details\n%s\n", string(80, '-').c_str());

--- a/egs_brachy/phantom.cpp
+++ b/egs_brachy/phantom.cpp
@@ -94,11 +94,11 @@ string space2underscore(std::string text) {
  * without specifying their volumes. Other geometry type need to have their
  * volumes specified using `phantom region volumes` inputs.
  * */
-const string EB_Phantom::autovol_phantom_geom_types[] = {"EGS_cSpheres", "EGS_cSphericalShell", "EGS_XYZGeometry", "EGS_RZ"};
+const string EB_Phantom::autovol_phantom_geom_types[] = {"EGS_cSpheres", "EGS_cSphericalShell", "EGS_XYZGeometry", "EGS_XYZGeometryT", "EGS_RZ"};
 
 
 /* geometries that support 3ddose files */
-const string EB_Phantom::threeddose_geom_types[] = {"EGS_cSpheres", "EGS_cSphericalShell", "EGS_XYZGeometry", "EGS_RZ"};
+const string EB_Phantom::threeddose_geom_types[] = {"EGS_cSpheres", "EGS_cSphericalShell", "EGS_XYZGeometry", "EGS_XYZGeometryT", "EGS_RZ"};
 
 /* initializer for phantom class */
 EB_Phantom::EB_Phantom(EGS_Application *parent, EGS_BaseGeometry *geom, set<int> global_regions, int nsource,


### PR DESCRIPTION
Add transformed XYZ geometries to list of geometries that have getMass() / getVolume() methods and that can write 3ddose files.