### PR TITLE
Un-ignore distributed .egsinp files under lib/ and eb_tests/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .idea/*
 *.make
 *.egsinp
+!egs_brachy/eb_tests/**/*.egsinp
+!egs_brachy/lib/**/*.egsinp
 *.egsdat
 *.mederr
 egsrun_*/


### PR DESCRIPTION
## Summary

Commit 30edbee added a global `*.egsinp` rule to keep local run artifacts out of git. That is useful, but this repo also distributes many `.egsinp` files under `egs_brachy/lib/` (examples) and `egs_brachy/eb_tests/` (regression tests).

`.gitignore` only affects **untracked** files. Already-committed inputs keep being tracked, but any **new** or **re-added** `.egsinp` in those directories would be silently skipped by `git add` unless someone remembered `git add -f`.

This adds negation rules for those paths so distributed inputs stay easy to commit while run-generated `.egsinp` files elsewhere remain ignored.

## Test plan

- [x] `git check-ignore` confirms new `.egsinp` under `egs_brachy/eb_tests/` and `egs_brachy/lib/` are not ignored
- [x] `git check-ignore` confirms `.egsinp` at repo root (typical run output) is still ignored


Made with [Cursor](https://cursor.com)