### PR TITLE
Clean up egs_brachy startup and volume-correction log output.

### DIFF
--- a/egs_brachy/eb_volcor.cpp
+++ b/egs_brachy/eb_volcor.cpp
@@ -237,7 +237,6 @@ void Options::setCoveredThreshold() {
 
     int err = input->getInput("total coverage threshold %", covered_threshold);
     if (err) {
-        egsWarning("The input 'total coverage threshold %%' input was not found. Using 99.9%\n");
         covered_threshold = 99.9;
     }
 

--- a/egs_brachy/eb_volcor.h
+++ b/egs_brachy/eb_volcor.h
@@ -218,6 +218,7 @@ struct Results {
     double npoints; /*!< what was the total number of points used for the VC */
     EGS_Float bounds_volume; /*!< what was the volume of the bounding shape */
     EGS_Float other_volume; /*!< what was the estimated volume of the inscribed geometry */
+    EGS_Float covered_threshold_pct; /*!< total coverage threshold in percent */
 
     map<int, vector<int> > regions_corrected;
 
@@ -228,7 +229,8 @@ struct Results {
         density(0),
         npoints(0),
         bounds_volume(0),
-        other_volume(0) {};
+        other_volume(0),
+        covered_threshold_pct(0) {};
 
     Results(Options *opts):
         success(0),
@@ -238,6 +240,8 @@ struct Results {
         density = opts->density;
         npoints =  opts->npoints;
         bounds_volume = opts->bounds_volume;
+        covered_threshold_pct = opts->covered_threshold <= 1. ?
+            opts->covered_threshold * 100. : opts->covered_threshold;
     }
 
     void outputResults(string extra="") {
@@ -251,6 +255,7 @@ struct Results {
         }
 
         egsInformation("Time taken                   = %.2G s\n", time);
+        egsInformation("Total coverage threshold %%   = %.4G\n", covered_threshold_pct);
         egsInformation("Density of points used       = %.0E points/cm^-3\n", density);
         egsInformation("Number of source points used = %G\n", npoints);
         egsInformation("Bounding shape volume        = %.4E cm^3\n", bounds_volume);

--- a/egs_brachy/egs_brachy.cpp
+++ b/egs_brachy/egs_brachy.cpp
@@ -106,8 +106,6 @@ void printParticleWithSpherical(EGS_Particle p) {
 }
 
 
-string EB_Application::revision = "$Revision: 0.9.1 $";
-
 const EGS_Float EB_Application::DEFAULT_BCSE_FACTOR = 100;
 
 
@@ -119,10 +117,6 @@ void EB_Application::describeUserCode() const {
         "\n               *                                                 *"
         "\n               ***************************************************"
         "\n\n");
-    egsInformation("This is EB_Application %s based on\n"
-                   "      EGS_AdvancedApplication %s\n\n",
-                   egsSimplifyCVSKey(revision).c_str(),
-                   egsSimplifyCVSKey(base_revision).c_str());
 }
 
 void EB_Application::describeSimulation() {

--- a/egs_brachy/egs_brachy.h
+++ b/egs_brachy/egs_brachy.h
@@ -199,9 +199,6 @@ class APP_EXPORT EB_Application : public EGS_AdvancedApplication {
     ogzstream *gz_data_out;  ///< GZip file for outputing egsdat
     igzstream *gz_data_in;  ///< GZip file for outputing egsdat
 
-    static string revision;    ///< the usercode revision number
-
-
     /*! \brief set up Phantom objects for any geometries that user has
      * requested scoring for */
     int createPhantoms();


### PR DESCRIPTION
Drop the stale EB_Application revision line, silence the default total-coverage-threshold init warning, and report the threshold in volume-correction results instead.