### PR TITLE
Use $EGS_HOME paths in distributed lib example inputs.

### DIFF
--- a/egs_brachy/lib/examples/ex_PeppaBreastHDR192Ir.egsinp
+++ b/egs_brachy/lib/examples/ex_PeppaBreastHDR192Ir.egsinp
@@ -24,7 +24,7 @@
     AP = 0.001
     UP = 1.500
 
-    material data file = lib/media/material.dat
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -49,8 +49,8 @@
         name = phantom
         library = egs_glib
         type = egsphant
-        egsphant file = lib/geometry/phantoms/egsphant/PeppaBreastHDR192Ir_MBDCA-WG.egsphant.gz
-	density file = lib/media/material.dat    
+        egsphant file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/egsphant/PeppaBreastHDR192Ir_MBDCA-WG.egsphant.gz
+	density file = $EGS_HOME/egs_brachy/lib/media/material.dat    
              # the .medialist file lists all media in the egsphant, 
              # along with their nominal densities (note that voxel-by-voxel 
              # densities may vary).
@@ -59,7 +59,7 @@
     :start geometry:         #source is MBDCA-WG Ir-192 source
         name = MBDCA-WG
         library = egs_glib
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
     :stop geometry:
 
     :start geometry:        #define wrapper - wrapping the source reduces 
@@ -92,13 +92,13 @@
 
             :start transformations:        #file defines dwell positions and 
                                            #source orientations
-                include file = lib/geometry/transformations/PeppaBreastHDR192Ir_MBDCA-WG_srcPosnRotn
+                include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/PeppaBreastHDR192Ir_MBDCA-WG_srcPosnRotn
             :stop transformations:
 
             :start region discovery:
                 action = region discovery #default
                 density of random points (cm^-3) = 1E8
-                include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
+                include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
             :stop region discovery:
         :stop inscribed geometry:
     :stop geometry:
@@ -113,7 +113,7 @@
                                       # agreement with Peppa et al MCNP 
                                       # results with no volume correction 
         density of random points (cm^-3) = 1E8
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
     :stop source volume correction:
 
 :stop volume correction:
@@ -125,18 +125,18 @@
         library = egs_isotropic_source
         name = MBDCA-WG
         charge = 0
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Ir192_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Ir192_NNDC_2.6_line.spectrum
         :stop spectrum:
     :stop source:
 
     :start transformations:       #specify source locations - use same file 
                                   #as for source geometry position and 
                                   #orientation (above)
-		include file = lib/geometry/transformations/PeppaBreastHDR192Ir_MBDCA-WG_srcPosnRotn
+		include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/PeppaBreastHDR192Ir_MBDCA-WG_srcPosnRotn
     :stop transformations:
 
     source weights = 0.0138,0.0156,0.0184,0.0144,0.0179,0.0173,0.0248,0.0138,0.0086,0.0063,0.0058,0.0086,0.0092,0.0063,0.0069,0.0058,0.0161,0.0265,0.0138,0.0046,0.0046,0.0086,0.0092,0.0127,0.0121,0.0144,0.0248,0.0363,0.0449,0.0138,0.0144,0.0190,0.0179,0.0213,0.0219,0.0161,0.0167,0.01325,0.0184,0.0230,0.0173,0.0104,0.0104,0.0098,0.0052,0.0086,0.01325,0.0156,0.0075,0.0058,0.0012,0.0023,0.0006,0.0012,0.0075,0.0161,0.0173,0.0092,0.0058,0.0058,0.0081,0.0104,0.0138,0.0109,0.0035,0.0323,0.0058,0.0127,0.0115,0.0040,0.0035,0.0069,0.0075,0.0115,0.0248,0.0127,0.0075,0.0092,0.0150
@@ -148,7 +148,7 @@
 :start scoring options:
 
     score energy deposition = yes
-    muen file = lib/muen/PeppaBreastHDR192Ir_MBDCA-WG_muen.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/PeppaBreastHDR192Ir_MBDCA-WG_muen.muendat
     muen for media = SKIN_1.09,AIR_0.0012,EXTERNAL_1.00,HEART_1.05,LUNGS_0.26,PTV_1.02,RIBS_1.92
     dose scaling factor = 7.60e+12 #=SK,ref*t_tot*w_max/(air kerma per hist)/100 --> will give dose in Gy
 	#note air kerma per hist  = (1.1592+/-0.0007)E-13 
@@ -163,5 +163,5 @@
 
 
 #-------------------------------------------------------------------------------
-include file = lib/transport/high_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/high_energy_default
 

--- a/egs_brachy/lib/examples/ex_brem_cyl.egsinp
+++ b/egs_brachy/lib/examples/ex_brem_cyl.egsinp
@@ -26,7 +26,7 @@
     AP = 0.001
     UP = 1.500
 
-    material data file = lib/media/material.dat
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 
 :stop media definition:
 
@@ -140,7 +140,7 @@
     score scatter dose = no		 # default is no. Does not score scatter
 					 # dose separately, but it is included.
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
     current result phantom region = phantom 1

--- a/egs_brachy/lib/examples/ex_hdr_source_with_applicator.egsinp
+++ b/egs_brachy/lib/examples/ex_hdr_source_with_applicator.egsinp
@@ -26,7 +26,7 @@
     AP = 0.001
     UP = 1.500
     
-    material data file = lib/media/material.dat    
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat    
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -35,25 +35,25 @@
     :start geometry:
         library = egs_glib
         name = air_box
-        include file = lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_air.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_air.geom
     :stop geometry:
 
     :start geometry:
         library = egs_glib
         name = phantom
-        include file = lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         library = egs_glib
         name = applicator
-        include file = lib/geometry/applicators/TG186/TG186_applicator.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/applicators/TG186/TG186_applicator.geom
     :stop geometry:
 
     :start geometry:
         library = egs_glib
         name = seed
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
     :stop geometry:
 
     :start geometry:
@@ -108,17 +108,17 @@
         name = MBDCA-WG
         charge = 0
 
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Ir192_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Ir192_NNDC_2.6_line.spectrum
         :stop spectrum:
 
     :stop source:
 
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_origin
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_origin
     :stop transformations:
 
     simulation source = MBDCA-WG
@@ -128,12 +128,12 @@
 #-------------------------------------------------------------------------------
 :start scoring options:
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
 :stop scoring options:
 
 #-------------------------------------------------------------------------------
 # Transport parameters
-include file = lib/transport/high_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/high_energy_default
 

--- a/egs_brachy/lib/examples/ex_hdr_source_with_applicator_create_volume_correction.egsinp
+++ b/egs_brachy/lib/examples/ex_hdr_source_with_applicator_create_volume_correction.egsinp
@@ -25,7 +25,7 @@
     AP = 0.001
     UP = 1.500
     
-    material data file = lib/media/material.dat    
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat    
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -34,25 +34,25 @@
     :start geometry:
         library = egs_glib
         name = air_box
-        include file = lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_air.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_air.geom
     :stop geometry:
 
     :start geometry:
         library = egs_glib
         name = phantom
-        include file = lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         library = egs_glib
         name = applicator
-        include file = lib/geometry/applicators/TG186/TG186_applicator.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/applicators/TG186/TG186_applicator.geom
     :stop geometry:
 
     :start geometry:
         library = egs_glib
         name = seed
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
     :stop geometry:
 
     :start geometry:
@@ -96,7 +96,7 @@
         correction type = correct
         density of random points (cm^-3) = 1E6
 
-        include file = lib/geometry/applicators/TG186/boundary.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/applicators/TG186/boundary.shape
     :stop extra volume correction:
 
 :stop volume correction:
@@ -110,17 +110,17 @@
         name = MBDCA-WG
         charge = 0
 
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Ir192_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Ir192_NNDC_2.6_line.spectrum
         :stop spectrum:
 
     :stop source:
 
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_origin
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_origin
     :stop transformations:
 
     simulation source = MBDCA-WG
@@ -130,7 +130,7 @@
 #-------------------------------------------------------------------------------
 :start scoring options:
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
     output volume correction files for phantoms = phantom    
@@ -140,5 +140,5 @@
 :stop scoring options:
 
 #-------------------------------------------------------------------------------
-include file = lib/transport/high_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/high_energy_default
 

--- a/egs_brachy/lib/examples/ex_mbdca-wg_center.egsinp
+++ b/egs_brachy/lib/examples/ex_mbdca-wg_center.egsinp
@@ -28,7 +28,7 @@
     AP = 0.001
     UP = 1.500
     
-    material data file = lib/media/material.dat    
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat    
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -37,19 +37,19 @@
     :start geometry:
         name = air_box
         library = egs_glib
-        include file = lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_air.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_air.geom
     :stop geometry:
 
     :start geometry:
         name = phantom
         library = egs_glib
-        include file = lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
     :stop geometry:
 
     :start geometry:
@@ -81,7 +81,7 @@
         correction type = correct
         density of random points (cm^-3) = 1E8
 
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
     :stop source volume correction:
 
 :stop volume correction:
@@ -94,17 +94,17 @@
         library = egs_isotropic_source
         charge = 0
 
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Ir192_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Ir192_NNDC_2.6_line.spectrum
         :stop spectrum:
 
     :stop source:
 
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_origin
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_origin
     :stop transformations:
 
     simulation source = MBDCA-WG
@@ -115,11 +115,11 @@
 :start scoring options:
 
     score energy deposition = no           #this is the default
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
 :stop scoring options:
 
 #-------------------------------------------------------------------------------
-include file = lib/transport/high_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/high_energy_default
 

--- a/egs_brachy/lib/examples/ex_mbdca-wg_center_water_only.egsinp
+++ b/egs_brachy/lib/examples/ex_mbdca-wg_center_water_only.egsinp
@@ -29,7 +29,7 @@
     AP = 0.001
     UP = 1.500
     
-    material data file = lib/media/material.dat    
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat    
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -38,19 +38,19 @@
     :start geometry:
         name = water_box
         library = egs_glib
-        include file = lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = phantom
         library = egs_glib
-        include file = lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
     :stop geometry:
 
     :start geometry:
@@ -82,7 +82,7 @@
         correction type = correct
         density of random points (cm^-3) = 1E8
 
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
     :stop source volume correction:
 
 :stop volume correction:
@@ -95,17 +95,17 @@
         library = egs_isotropic_source
         charge = 0
 
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Ir192_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Ir192_NNDC_2.6_line.spectrum
         :stop spectrum:
 
     :stop source:
 
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_origin
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_origin
     :stop transformations:
 
     simulation source = MBDCA-WG
@@ -117,11 +117,11 @@
 
     score energy deposition = no        #this is the default and tracklenth dose
 					#is computed by default
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
 :stop scoring options:
 
 #-------------------------------------------------------------------------------
-include file = lib/transport/high_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/high_energy_default
 

--- a/egs_brachy/lib/examples/ex_mbdca-wg_x7cm.egsinp
+++ b/egs_brachy/lib/examples/ex_mbdca-wg_x7cm.egsinp
@@ -28,7 +28,7 @@
     AP = 0.001
     UP = 1.500
 
-    material data file = lib/media/material.dat
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -37,19 +37,19 @@
     :start geometry:
         name = air_box
         library = egs_glib
-        include file = lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_air.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/50cmx50cmx50cm_box_xyz_air.geom
     :stop geometry:
 
     :start geometry:
         name = phantom
         library = egs_glib
-        include file = lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/20.1cmx20.1cmx20.1cm_1mm_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.geom
     :stop geometry:
 
     :start geometry:
@@ -60,13 +60,13 @@
         :start inscribed geometry:
             inscribed geometry name = seed
             :start transformations:
-                include file = lib/geometry/transformations/single_seed_at_x7cm
+                include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_x7cm
             :stop transformations:
 
             :start region discovery:
                 action = discover
                 density of random points (cm^-3) = 1E8
-                include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
+                include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
             :stop region discovery:
         :stop inscribed geometry:
     :stop geometry:
@@ -93,7 +93,7 @@
         correction type = correct
         density of random points (cm^-3) = 1E8
 
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/boundary.shape
     :stop source volume correction:
 
 :stop volume correction:
@@ -106,17 +106,17 @@
         library = egs_isotropic_source
         charge = 0
 
-        include file = lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Ir192_HDR/MBDCA-WG/MBDCA-WG.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Ir192_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Ir192_NNDC_2.6_line.spectrum
         :stop spectrum:
 
     :stop source:
 
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_x7cm
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_x7cm
     :stop transformations:
 
     simulation source = MBDCA-WG
@@ -127,11 +127,11 @@
 :start scoring options:
 
     score energy deposition = no
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
 :stop scoring options:
 
 #-------------------------------------------------------------------------------
-include file = lib/transport/high_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/high_energy_default
 

--- a/egs_brachy/lib/examples/ex_phase_space_and_spectrum_scoring.egsinp
+++ b/egs_brachy/lib/examples/ex_phase_space_and_spectrum_scoring.egsinp
@@ -21,7 +21,7 @@
     AP = 0.001
     UP = 1.500
     
-    material data file = lib/media/material.dat    
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat    
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -30,19 +30,19 @@
     :start geometry:
         name = box
         library = egs_glib
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = phantom
         library = egs_glib
-        include file = lib/geometry/phantoms/2.0cmx2.0cmx2.0cm_1mm_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/2.0cmx2.0cmx2.0cm_1mm_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
     :stop geometry:
 
     :start geometry:
@@ -74,7 +74,7 @@
       correction type = correct
       density of random points (cm^-3) = 1E9
 
-      include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
+      include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
   :stop source volume correction:
 
 :stop volume correction:
@@ -88,17 +88,17 @@
         name = TheraSeed_200
         charge = 0
 
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Pd103_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Pd103_NNDC_2.6_line.spectrum
         :stop spectrum:
 
     :stop source:
 
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_origin
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_origin
     :stop transformations:
 
     simulation source = TheraSeed_200
@@ -108,12 +108,12 @@
 #-------------------------------------------------------------------------------
 :start scoring options:
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
     # IAEA phase space scoring block
     :start phsp scoring:
-      phsp output directory = ./lib/phsp # where to output the phase space files
+      phsp output directory = $EGS_HOME/egs_brachy/lib/phsp # where to output the phase space files
       access mode = write      # 'write' to a new file or 'append' to 
                                #an existing one
       print header = yes
@@ -140,4 +140,4 @@
 :stop scoring options:
 
 #-------------------------------------------------------------------------------
-include file = lib/transport/low_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/low_energy_default

--- a/egs_brachy/lib/examples/ex_prostate_permanent_implant.egsinp
+++ b/egs_brachy/lib/examples/ex_prostate_permanent_implant.egsinp
@@ -22,8 +22,7 @@
     AP = 0.001
     UP = 1.500
 
-    material data file = lib/media/material.dat
-    #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -32,19 +31,19 @@
     :start geometry:
        name = box
        library = egs_glib
-       include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_prostate.geom
+       include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_prostate.geom
     :stop geometry:
 
     :start geometry:
        name = phantom
        library = egs_glib
-       include file = lib/geometry/phantoms/ptv_3.4cmx2.8cmx3.8cm_2mm_xyz_prostate.geom
+       include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/ptv_3.4cmx2.8cmx3.8cm_2mm_xyz_prostate.geom
     :stop geometry:
 
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
     :stop geometry:
 
     # The egs_autoenvelope library allows for more efficient simulations with 
@@ -62,7 +61,7 @@
             # the 'source' input block below
             
             :start transformations:
-                include file = lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
+                include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
                 #the above file lists 100 transformations and thus
                 #inserts 100 seeds
             :stop transformations:
@@ -79,7 +78,7 @@
 
                 # define shape which defines boundaries of volume of interest 
                 # where egs_autoenvelope will search for inscribed geometries
-                include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
+                include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
             :stop region discovery:
 
         :stop inscribed geometry:
@@ -115,7 +114,7 @@
 
         # shape which defines the boundaries of the volume of interest 
         # where egs_brachy will search for inscribed source geometries
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
     :stop source volume correction:
 
 :stop volume correction:
@@ -129,11 +128,11 @@
         name = 6711
         charge = 0
 
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/I125_NCRP_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/I125_NCRP_line.spectrum
         :stop spectrum:
 
     :stop source:
@@ -141,7 +140,7 @@
     # the source transformations should usually be identical to the 
     # transformations used in autoenvelope
     :start transformations:
-        include file = lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
     :stop transformations:
 
     simulation source = 6711
@@ -151,7 +150,7 @@
 #-------------------------------------------------------------------------------
 :start scoring options:
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = PROSTATE_WW86 # we score in prostate tissue, 
                                    #instead of water
 
@@ -171,5 +170,5 @@
 
 #-------------------------------------------------------------------------------
 # Transport parameters
-include file = lib/transport/low_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 

--- a/egs_brachy/lib/examples/ex_prostate_permanent_implant_TG43.egsinp
+++ b/egs_brachy/lib/examples/ex_prostate_permanent_implant_TG43.egsinp
@@ -22,7 +22,7 @@
     AP = 0.001
     UP = 1.500
 
-    material data file = lib/media/material.dat
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -31,19 +31,19 @@
     :start geometry:
         name = box
         library = egs_glib
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = phantom
         library = egs_glib
-        include file = lib/geometry/phantoms/ptv_3.4cmx2.8cmx3.8cm_2mm_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/ptv_3.4cmx2.8cmx3.8cm_2mm_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
     :stop geometry:
 
     # The egs_autoenvelope library allows for more efficient simulations 
@@ -61,7 +61,7 @@
             # locations) in an external file since the information needs to be 
             # repeated in the 'source' input block below
             :start transformations:
-                include file = lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
+                include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
             :stop transformations:
 
             # egs_autoenvelope automatically detects which voxels of the base 
@@ -77,7 +77,7 @@
                    # the shape which defines the boundaries of the volume of 
                    # interest where egs_autoenvelope will search for 
                    # inscribed geometries
-                include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
+                include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
             :stop region discovery:
 
         :stop inscribed geometry:
@@ -115,7 +115,7 @@
 
             # shape which defines the boundaries of the volume of interest 
             # where egs_brachy will search for inscribed source geometries
-       include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
+       include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
     :stop source volume correction:
 
 :stop volume correction:
@@ -129,11 +129,11 @@
         name = 6711
         charge = 0
 
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/I125_NCRP_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/I125_NCRP_line.spectrum
         :stop spectrum:
 
     :stop source:
@@ -141,7 +141,7 @@
         # the source transformations should usually be identical to the 
         # transformations used in autoenvelope
     :start transformations:
-        include file = lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
     :stop transformations:
 
     simulation source = 6711
@@ -151,11 +151,11 @@
 #-------------------------------------------------------------------------------
 :start scoring options:
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
 :stop scoring options:
 
 #-------------------------------------------------------------------------------
 # Transport parameters
-include file = lib/transport/low_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/low_energy_default

--- a/egs_brachy/lib/examples/ex_prostate_permanent_implant_pegs4.egsinp
+++ b/egs_brachy/lib/examples/ex_prostate_permanent_implant_pegs4.egsinp
@@ -32,19 +32,19 @@
     :start geometry:
        name = box
        library = egs_glib
-       include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_prostate.geom
+       include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_prostate.geom
     :stop geometry:
 
     :start geometry:
         name = phantom
         library = egs_glib
-        include file = lib/geometry/phantoms/ptv_3.4cmx2.8cmx3.8cm_2mm_xyz_prostate.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/ptv_3.4cmx2.8cmx3.8cm_2mm_xyz_prostate.geom
     :stop geometry:
 
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
     :stop geometry:
 
     # The egs_autoenvelope library allows for more efficient simulations with
@@ -62,7 +62,7 @@
             # the 'source' input block below
             
             :start transformations:
-                include file = lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
+                include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
                 #the above file lists 100 transformations and thus
                 #inserts 100 seeds
             :stop transformations:
@@ -79,7 +79,7 @@
 
                 # define shape which defines boundaries of volume of interest 
                 # where egs_autoenvelope will search for inscribed geometries
-                include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
+                include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
             :stop region discovery:
 
         :stop inscribed geometry:
@@ -115,7 +115,7 @@
 
         # shape which defines the boundaries of the volume of interest 
         # where egs_brachy will search for inscribed source geometries
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
     :stop source volume correction:
 
 :stop volume correction:
@@ -129,11 +129,11 @@
         name = 6711
         charge = 0
 
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/I125_NCRP_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/I125_NCRP_line.spectrum
         :stop spectrum:
 
     :stop source:
@@ -141,7 +141,7 @@
     # the source transformations should usually be identical to the
     # transformations used in autoenvelope
     :start transformations:
-        include file = lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/100seeds_grid_5x7mmx4x7mmx5x8mm_0.5mm_perturb_in_z
     :stop transformations:
 
     simulation source = 6711
@@ -151,7 +151,7 @@
 #-------------------------------------------------------------------------------
 :start scoring options:
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = PROSTATE_WW86 # we score in prostate tissue, 
                                    #instead of water
 
@@ -171,5 +171,5 @@
 
 #-------------------------------------------------------------------------------
 # Transport parameters
-include file = lib/transport/low_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 

--- a/egs_brachy/lib/examples/ex_single_source.egsinp
+++ b/egs_brachy/lib/examples/ex_single_source.egsinp
@@ -25,8 +25,7 @@
     AP = 0.001
     UP = 1.500
     
-    material data file = lib/media/material.dat    
-    #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat    
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -39,24 +38,21 @@
 				#which allows files to be included into the
 				#input file. Very useful for defining
 				#commonly used geometries.
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
-        #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
     :stop geometry:
 
     # The volume in which we want to score dose
     :start geometry:
         name = phantom
         library = egs_glib
-        include file = lib/geometry/phantoms/2.0cmx2.0cmx2.0cm_1mm_xyz_water.geom
-        #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/2.0cmx2.0cmx2.0cm_1mm_xyz_water.geom
     :stop geometry:
 
     # The source geometry
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
-        #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
     :stop geometry:
 
     # Inscribe the seed in the scoring phantom
@@ -96,11 +92,8 @@
       correction type = correct
       density of random points (cm^-3) = 1E8
 
-      # This include file statement defines a shape that encompasses the 
-      # entire source geometry.
-      # Volume correction will only occur within the boundaries of this shape.
-      include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
-      #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+      # Shape encompassing the entire source geometry (volume correction boundary).
+      include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
   :stop source volume correction:
 
 :stop volume correction:
@@ -114,20 +107,17 @@
         name = TheraSeed200
         charge = 0
 
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.shape
-        #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Pd103_NNDC_2.6_line.spectrum
-            #to run in batch, insert value of $EGS_HOME/egs_brachy/ before lib
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Pd103_NNDC_2.6_line.spectrum
         :stop spectrum:
     :stop source:
 
     # The position of the source
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_origin
-        #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_origin
     :stop transformations:
 
     # The source needs to be explicitly specified to egs_brachy. 
@@ -145,8 +135,7 @@
    
        # The path to a file containing mass-energy absorption data for the 
        # relevant media in the simulation    
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
-       #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
        # Specify which media dose is scored in
     muen for media = WATER_0.998
 
@@ -154,6 +143,5 @@
 
 #-------------------------------------------------------------------------------
 # Transport parameters
-include file = lib/transport/low_energy_default
-#to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib
+include file = $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 

--- a/egs_brachy/lib/examples/ex_single_source_from_phase_space.egsinp
+++ b/egs_brachy/lib/examples/ex_single_source_from_phase_space.egsinp
@@ -25,7 +25,7 @@
     AP = 0.001
     UP = 1.500
     
-    material data file = lib/media/material.dat    
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat    
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -34,19 +34,19 @@
     :start geometry:
         name = box
         library = egs_glib
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
     :stop geometry:
 
     :start geometry:
        name = phantom
        library = egs_glib
-       include file = lib/geometry/phantoms/2.0cmx2.0cmx2.0cm_1mm_xyz_water.geom
+       include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/2.0cmx2.0cmx2.0cm_1mm_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
     :stop geometry:
 
     :start geometry:
@@ -78,7 +78,7 @@
       correction type = correct
       density of random points (cm^-3) = 1E9
 
-      include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
+      include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
     :stop source volume correction:
 
 :stop volume correction:
@@ -89,11 +89,11 @@
     :start source:
       library = eb_iaeaphsp_source
       name = TheraSeed_200
-      header file = lib/phsp/ex_single_source_phase_space_and_spectrum_scoring.phsp.IAEAheader
+      header file = $EGS_HOME/egs_brachy/lib/phsp/ex_single_source_phase_space_and_spectrum_scoring.phsp.IAEAheader
     :stop source:
 
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_origin
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_origin
     :stop transformations:
 
     simulation source = TheraSeed_200
@@ -103,7 +103,7 @@
 #-------------------------------------------------------------------------------
 :start scoring options:
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
 :stop scoring options:
@@ -124,5 +124,5 @@
 
 #-------------------------------------------------------------------------------
 # Transport parameters
-include file = lib/transport/low_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 

--- a/egs_brachy/lib/examples/ex_single_source_phase_space_and_spectrum_scoring.egsinp
+++ b/egs_brachy/lib/examples/ex_single_source_phase_space_and_spectrum_scoring.egsinp
@@ -24,8 +24,7 @@
     AP = 0.001
     UP = 1.500
     
-    material data file = lib/media/material.dat    
-    #to run in batch, insert value of $EGS_HOME/egs_brachy/ before all lib/
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat    
 :stop media definition:
 
 #-------------------------------------------------------------------------------
@@ -34,19 +33,19 @@
     :start geometry:
         name = box
         library = egs_glib
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = phantom
         library = egs_glib
-        include file = lib/geometry/phantoms/2.0cmx2.0cmx2.0cm_1mm_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/2.0cmx2.0cmx2.0cm_1mm_xyz_water.geom
     :stop geometry:
 
     :start geometry:
         name = seed
         library = egs_glib
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
     :stop geometry:
 
     :start geometry:
@@ -78,7 +77,7 @@
         correction type = correct
         density of random points (cm^-3) = 1E9
 
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
     :stop source volume correction:
 
 :stop volume correction:
@@ -91,17 +90,17 @@
         name = TheraSeed_200
         charge = 0
 
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Pd103_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Pd103_NNDC_2.6_line.spectrum
         :stop spectrum:
 
     :stop source:
 
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_origin
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_origin
         # this is a null transformation
     :stop transformations:
 
@@ -112,12 +111,12 @@
 #-------------------------------------------------------------------------------
 :start scoring options:
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
     # IAEA phase space scoring block
     :start phsp scoring:
-        phsp output directory = ./lib/phsp # where to output phase space file
+        phsp output directory = $EGS_HOME/egs_brachy/lib/phsp # where to output phase space file
         access mode = write              # use 'write' for a new file or 'append' 
                                          #  to add to an existing one
         print header = yes
@@ -147,5 +146,5 @@
 :stop scoring options:
 
 #-------------------------------------------------------------------------------
-include file = lib/transport/low_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 

--- a/egs_brachy/lib/examples/ex_xray_sph.egsinp
+++ b/egs_brachy/lib/examples/ex_xray_sph.egsinp
@@ -26,8 +26,7 @@
     AP = 0.001
     UP = 1.500
 
-    material data file = lib/media/material.dat
-    #to run in batch, insert local value of $EGS_HOME/egs_brachy/ before lib/
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 
 :stop media definition:
 
@@ -116,7 +115,7 @@
     :stop source:
 
     :start transformations:
-        include file = lib/geometry/transformations/single_seed_at_origin
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/single_seed_at_origin
         # although not technically necessary for sources at the origin, if this
         # input is missing, a warning will be generated when the simulation is
         # launched
@@ -129,7 +128,7 @@
 #-------------------------------------------------------------------------------
 :start scoring options:
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
 
     current result phantom region = phantom 1 
@@ -148,5 +147,5 @@
 
 #--------------------------------------------------------------------------
 # Transport parameters
-include file = lib/transport/xray_source
+include file = $EGS_HOME/egs_brachy/lib/transport/xray_source
 

--- a/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/BEBIG16mm-hetero-I125-S06_3rdSeedActive-.egsinp
+++ b/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/BEBIG16mm-hetero-I125-S06_3rdSeedActive-.egsinp
@@ -17,7 +17,7 @@
 
 
 :start media definition:
-    material data file = lib/media/material.dat
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 :stop media definition:
 
 :start run mode:
@@ -33,14 +33,14 @@
 	:start geometry:
         library = egs_glib
         name = water_box
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
 	:stop geometry:
 	
 #The scoring phantom
 	:start geometry:
         library = egs_glib
         name = water_phantom
-		include file =lib/geometry/phantoms/COMSphant.geom
+		include file =$EGS_HOME/egs_brachy/lib/geometry/phantoms/COMSphant.geom
 		# COMSphantLarge.geom
 	:stop geometry:
 
@@ -48,7 +48,7 @@
     :start geometry:
         library = egs_glib
         name = empty_plaque
-        include file = lib/geometry/eye_plaques/BEBIG/BEBIG16mm/BEBIG16mm.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/eye_plaques/BEBIG/BEBIG16mm/BEBIG16mm.geom
     :stop geometry
 	
     :start geometry:
@@ -64,7 +64,7 @@
 	:start geometry:
         library = egs_glib
         name = seed
-        include file = lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/IsoSeed_I25_S06_S16.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/IsoSeed_I25_S06_S16.geom
     :stop geometry
 	
 #Insertion of the seeds into the plaque
@@ -79,7 +79,7 @@
             inscribed geometry name = seed
 
             :start transformations:
-               # include file = lib/geometry/transformations/eye_plaques/COMS16mm
+               # optional plaque transforms: $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
 
 			  # Translations for a 16mm BEBIG Eye Plaque
 
@@ -154,7 +154,7 @@
 				correction type = discover
                 density of random points (cm^-3) = 1E8
                 total coverage threshold % = 98
-                include file = lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/boundary.shape
+                include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/boundary.shape
             :stop region discovery:
 
         :stop inscribed geometry:
@@ -219,11 +219,11 @@
         name = BEBIG_I125-S06/S16
         charge = 0
 
-        include file = lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/IsoSeed_I25_S06_S16.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/IsoSeed_I25_S06_S16.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/I125_NCRP_line.spectrum 
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/I125_NCRP_line.spectrum 
 		
         :stop spectrum:
 
@@ -231,7 +231,7 @@
 
     :start transformations :
 	
-       # include file = lib/geometry/transformations/eye_plaques/COMS16mm
+       # optional plaque transforms: $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
 	   # First active source in 16mm BEBIG plaque
 	   
 	#  :start transformation:
@@ -265,7 +265,7 @@
      #score energy deposition = yes
      output voxel info files  = yes
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
     dose scaling factor = 1.00 # For absolute dose   
 	# For  dose/sk for I-6711= 2.699551E+11 
@@ -274,7 +274,7 @@
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 #   	Transport parameters	#
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-include file = lib/transport/low_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 
 :start rng definition:
     type = ranmar

--- a/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/BEBIG16mm-hetero-I125-S06_AllSeedActive-TG43Superpositionl.egsinp
+++ b/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/BEBIG16mm-hetero-I125-S06_AllSeedActive-TG43Superpositionl.egsinp
@@ -22,7 +22,7 @@
 
 
 :start media definition:
-    material data file = lib/media/material.dat
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 :stop media definition:
 
 
@@ -36,14 +36,14 @@
 	:start geometry:
         library = egs_glib
         name = water_box
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
 	:stop geometry:
 	
 #The scoring phantom
 	:start geometry:
         library = egs_glib
         name = water_phantom
-		include file = lib/geometry/phantoms/COMSphant.geom
+		include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/COMSphant.geom
 		# COMSphantLarge.geom
 	:stop geometry:
 
@@ -51,7 +51,7 @@
     :start geometry:
         library = egs_glib
         name = empty_plaque
-        include file = lib/geometry/eye_plaques/BEBIG/BEBIG16mm/BEBIG16mm.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/eye_plaques/BEBIG/BEBIG16mm/BEBIG16mm.geom
     :stop geometry
 	
     :start geometry:
@@ -67,7 +67,7 @@
 	:start geometry:
         library = egs_glib
         name = seed
-        include file = lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/IsoSeed_I25_S06_S16.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/IsoSeed_I25_S06_S16.geom
     :stop geometry
 	
 #Insertion of the seeds into the plaque
@@ -83,7 +83,7 @@
             inscribed geometry name = seed
 
             :start transformations:
-               # include file = geometry/transformations/eye_plaques/COMS16mm " 
+               # optional plaque transforms: geometry/transformations/eye_plaques/COMS16mm
 			   # You can read the firls from the path #to your egs_brachy ot just simply copy the source trasnformations as you see in below
 
 			  # Translations for a 16mm BEBIG Eye Plaque
@@ -158,7 +158,7 @@
 			:start region discovery:
 				correction type = discover
                 density of random points (cm^-3) = 1E7
-                include file = lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/boundary.shape
+                include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/boundary.shape
             :stop region discovery:
 
         :stop inscribed geometry:
@@ -224,18 +224,18 @@
         name = BEBIG_I125-S06/S16
         charge = 0
 
-        include file = lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/IsoSeed_I25_S06_S16.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/IsoSeed_I25_S06_S16/IsoSeed_I25_S06_S16.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/I125_NCRP_line.spectrum 
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/I125_NCRP_line.spectrum 
         :stop spectrum:
 
     :stop source:
 
     :start transformations :
 	
-       #  include file =  lib/geometry/transformations/eye_plaques/COMS16mm
+       # optional plaque transforms: $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
 	   #  ALL 13 seeds are active in  BEBIG16mm plaque
 	   
 	# Translations for a 16mm BEBIG Eye Plaque
@@ -323,7 +323,7 @@
      #score energy deposition = yes
      output voxel info files  = yes
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
     dose scaling factor = 1.00 # For absolute dose 
 	#  For  dose/sk for I-6711= 2.699551E+11    . Sk is from the CLRPv2 TG43 database 
@@ -332,7 +332,7 @@
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 #   	Transport parameters	#
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-include file =  lib/transport/low_energy_default
+include file =  $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 
 :start rng definition:
     type = ranmar

--- a/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/COMS16mm-I125-6711-hetero-splitTransforms.egsinp
+++ b/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/COMS16mm-I125-6711-hetero-splitTransforms.egsinp
@@ -36,7 +36,7 @@
 
 
 :start media definition:
-    material data file = lib/media/material.dat
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 :stop media definition:
 
 :start run mode:
@@ -52,21 +52,21 @@
 	:start geometry:
         library = egs_glib
         name = water_box
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
 	:stop geometry:
 	
 #The scoring phantom
 	:start geometry:
         library = egs_glib
         name = water_phantom
-		include file = lib/geometry/phantoms/COMSphant.geom
+		include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/COMSphant.geom
 	:stop geometry:
 
 #The plaque to be used
     :start geometry:
         library = egs_glib
         name = empty_plaque
-        include file = lib/geometry/eye_plaques/COMS/COMS16mm/COMS16mm.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/eye_plaques/COMS/COMS16mm/COMS16mm.geom
     :stop geometry
 	
     :start geometry:
@@ -82,7 +82,7 @@
 	:start geometry:
         library = egs_glib
         name = seed
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
     :stop geometry
 	
 # Local seed placements (same file as source definition below)
@@ -97,13 +97,13 @@
             inscribed geometry name = seed
 
             :start transformations:
-                include file = lib/geometry/transformations/eye_plaques/COMS16mm
+                include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
             :stop transformations:
 
 			:start region discovery:
 				correction type = discover
                 density of random points (cm^-3) = 1E7
-                include file =  lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
+                include file =  $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
             :stop region discovery:
 
         :stop inscribed geometry:
@@ -115,7 +115,7 @@
         library = egs_gtransformed
         my geometry = plaque_w_seeds
         :start transformation:
-            include file = lib/geometry/transformations/eye_plaques/COMS16mm_example_pose
+            include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm_example_pose
         :stop transformation:
         name = plaque_in_phantom
     :stop geometry:
@@ -177,24 +177,24 @@
         name = 6711
         charge = 0
 
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/I125_NCRP_line.spectrum 
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/I125_NCRP_line.spectrum 
         :stop spectrum:
 
     :stop source:
 
 # Local seed placements (same file as geometry inscriptions above)
     :start transformations :
-        include file = lib/geometry/transformations/eye_plaques/COMS16mm
+        include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
     :stop transformations:
 
 # Shared applicator pose (must match egs_gtransformed above)
     :start source coordinate transform:
         :start transformation:
-            include file = lib/geometry/transformations/eye_plaques/COMS16mm_example_pose
+            include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm_example_pose
         :stop transformation:
     :stop source coordinate transform:
 
@@ -210,7 +210,7 @@
      #score energy deposition = yes
      output voxel info files  = yes
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
     dose scaling factor = 1.00 # For absolute dose # 
 	# scaling factor for  dose/sk for I-6711= 2.699551E+11 , Pd103-200= from CLRP_Epv2 paper  ,  Cs131-Isoray=  From CLRP_EPv2 paper Medphys 2021     . Sk is from the CLRPv2 TG43 database 
@@ -219,7 +219,7 @@
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 #   	Transport parameters	#
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-include file =  lib/transport/low_energy_default
+include file =  $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 
 :start rng definition:
     type = ranmar

--- a/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/COMS16mm-I125-6711-hetero.egsinp
+++ b/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/COMS16mm-I125-6711-hetero.egsinp
@@ -18,7 +18,7 @@
 
 
 :start media definition:
-    material data file = lib/media/material.dat
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 :stop media definition:
 
 :start run mode:
@@ -34,14 +34,14 @@
 	:start geometry:
         library = egs_glib
         name = water_box
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
 	:stop geometry:
 	
 #The scoring phantom
 	:start geometry:
         library = egs_glib
         name = water_phantom
-		include file = lib/geometry/phantoms/COMSphant.geom
+		include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/COMSphant.geom
 		# COMSphantLarge.geom
 	:stop geometry:
 
@@ -49,7 +49,7 @@
     :start geometry:
         library = egs_glib
         name = empty_plaque
-        include file = lib/geometry/eye_plaques/COMS/COMS16mm/COMS16mm.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/eye_plaques/COMS/COMS16mm/COMS16mm.geom
     :stop geometry
 	
     :start geometry:
@@ -65,7 +65,7 @@
 	:start geometry:
         library = egs_glib
         name = seed
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.geom
     :stop geometry
 	
 #Insertion of the seeds into the plaque
@@ -80,13 +80,13 @@
             inscribed geometry name = seed
 
             :start transformations:
-                include file = lib/geometry/transformations/eye_plaques/COMS16mm
+                include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
             :stop transformations:
 
 			:start region discovery:
 				correction type = discover
                 density of random points (cm^-3) = 1E7
-                include file =  lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
+                include file =  $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/boundary.shape
             :stop region discovery:
 
         :stop inscribed geometry:
@@ -150,17 +150,17 @@
         name = 6711
         charge = 0
 
-        include file = lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/I125_LDR/OncoSeed_6711/OncoSeed_6711.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/I125_NCRP_line.spectrum 
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/I125_NCRP_line.spectrum 
         :stop spectrum:
 
     :stop source:
 
     :start transformations :
-        include file =  lib/geometry/transformations/eye_plaques/COMS16mm
+        include file =  $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
     :stop transformations:
 
     simulation source = 6711
@@ -175,7 +175,7 @@
      #score energy deposition = yes
      output voxel info files  = yes
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
     dose scaling factor = 1.00 # For absolute dose # 
 	# scaling factor for  dose/sk for I-6711= 2.699551E+11 , Pd103-200= from CLRP_Epv2 paper  ,  Cs131-Isoray=  From CLRP_EPv2 paper Medphys 2021     . Sk is from the CLRPv2 TG43 database 
@@ -184,7 +184,7 @@
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 #   	Transport parameters	#
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-include file =  lib/transport/low_energy_default
+include file =  $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 
 :start rng definition:
     type = ranmar

--- a/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/COMS16mm-Pd103_200_homo-TG43-no_Intersed.egsinp
+++ b/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/COMS16mm-Pd103_200_homo-TG43-no_Intersed.egsinp
@@ -18,7 +18,7 @@
 
 
 :start media definition:
-    material data file = lib/media/material.dat
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat
 :stop media definition:
 
 # :start run mode:
@@ -34,14 +34,14 @@
 	:start geometry:
         library = egs_glib
         name = water_box
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
 	:stop geometry:
 	
 #The scoring phantom
 	:start geometry:
         library = egs_glib
         name = water_phantom
-		include file = lib/geometry/phantoms/COMSphant.geom
+		include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/COMSphant.geom
 		# COMSphantLarge.geom
 	:stop geometry:
 
@@ -49,7 +49,7 @@
     :start geometry:
         library = egs_glib
         name = empty_plaque
-        include file = lib/geometry/eye_plaques/COMS/COMS16mm/COMS16mm_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/eye_plaques/COMS/COMS16mm/COMS16mm_water.geom
     :stop geometry
 	
     :start geometry:
@@ -65,7 +65,7 @@
 	:start geometry:
         library = egs_glib
         name = seed
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.geom
     :stop geometry
 	
 #Insertion of the seeds into the plaque
@@ -81,13 +81,13 @@
             inscribed geometry name = seed
 
             :start transformations:
-                include file = lib/geometry/transformations/eye_plaques/COMS16mm
+                include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
             :stop transformations:
 
 			:start region discovery:
 				correction type = discover
                 density of random points (cm^-3) = 1E7
-                include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
+                include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/boundary.shape
             :stop region discovery:
 
         :stop inscribed geometry:
@@ -154,18 +154,18 @@
         name = Pd103_Theraseed_200
         charge = 0
 
-        include file = lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.shape
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Pd103_LDR/TheraSeed_200/TheraSeed_200.shape
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Pd103_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Pd103_NNDC_2.6_line.spectrum
 			
         :stop spectrum:
 
     :stop source:
 
     :start transformations :
-        include file =  lib/geometry/transformations/eye_plaques/COMS16mm
+        include file =  $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
     :stop transformations:
 
     simulation source = Pd103_Theraseed_200
@@ -180,7 +180,7 @@
      #score energy deposition = yes
      output voxel info files  = yes
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
     dose scaling factor = 1.00 # For absolute dose # 2.699551E+11    # 
 	# Habib: scaling factor,  dose/sk for I-6711= 2.699551E+11 , Pd103-200=1.556154E+09 ,  Cs131-Isoray=       . Sk is from the CLRPv2 TG43 database 
@@ -189,7 +189,7 @@
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 #   	Transport parameters	#
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-include file =  lib/transport/low_energy_default
+include file =  $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 
 :start rng definition:
     type = ranmar

--- a/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/Representative_COMS_thin_acrylic-CS131-rev2_heterol.egsinp
+++ b/egs_brachy/lib/geometry/eye_plaques/sample eye plaque input template  files/Representative_COMS_thin_acrylic-CS131-rev2_heterol.egsinp
@@ -19,7 +19,7 @@
 
 
 :start media definition:
-    material data file = lib/media/material.dat 
+    material data file = $EGS_HOME/egs_brachy/lib/media/material.dat 
 :stop media definition:
 
 :start run mode:
@@ -35,14 +35,14 @@
 	:start geometry:
         library = egs_glib
         name = water_box
-        include file = lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/30cmx30cmx30cm_box_xyz_water.geom
 	:stop geometry:
 	
 #The scoring phantom
 	:start geometry:
         library = egs_glib
         name = water_phantom
-		include file = lib/geometry/phantoms/COMSphant.geom
+		include file = $EGS_HOME/egs_brachy/lib/geometry/phantoms/COMSphant.geom
 		# COMSphantLarge.geom
 	:stop geometry:
 
@@ -50,7 +50,7 @@
     :start geometry:
         library = egs_glib
         name = empty_plaque
-        include file = lib/geometry/eye_plaques/Representative_models/COMS_thin_acrylic_Cta/COMS_thin_acrylic.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/eye_plaques/Representative_models/COMS_thin_acrylic_Cta/COMS_thin_acrylic.geom
     :stop geometry
 	
     :start geometry:
@@ -66,7 +66,7 @@
 	:start geometry:
         library = egs_glib
         name = seed
-        include file = lib/geometry/sources/Cs131_LDR/Proxcelan_CS1_rev2/Proxcelan_CS1_rev2.geom
+        include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Cs131_LDR/Proxcelan_CS1_rev2/Proxcelan_CS1_rev2.geom
 	
     :stop geometry
 	
@@ -82,13 +82,13 @@
             inscribed geometry name = seed
 
             :start transformations:
-                include file = lib/geometry/transformations/eye_plaques/COMS16mm
+                include file = $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
             :stop transformations:
 
 			:start region discovery:
 				correction type = discover
                 density of random points (cm^-3) = 1E7
-                include file = lib/geometry/sources/Cs131_LDR/Proxcelan_CS1_rev2/boundary.shape
+                include file = $EGS_HOME/egs_brachy/lib/geometry/sources/Cs131_LDR/Proxcelan_CS1_rev2/boundary.shape
 
             :stop region discovery:
 
@@ -153,12 +153,12 @@
         name = Cs131_CS1_rev2
         charge = 0
 
-       include file =lib/geometry/sources/Cs131_LDR/Proxcelan_CS1_rev2/Proxcelan_CS1_rev2.shape
+       include file =$EGS_HOME/egs_brachy/lib/geometry/sources/Cs131_LDR/Proxcelan_CS1_rev2/Proxcelan_CS1_rev2.shape
 		
 
         :start spectrum:
             type = tabulated spectrum
-            spectrum file = lib/spectra/Cs131_NNDC_2.6_line.spectrum
+            spectrum file = $EGS_HOME/egs_brachy/lib/spectra/Cs131_NNDC_2.6_line.spectrum
 			
 			
         :stop spectrum:
@@ -166,7 +166,7 @@
     :stop source:
 
     :start transformations :
-        include file =  lib/geometry/transformations/eye_plaques/COMS16mm
+        include file =  $EGS_HOME/egs_brachy/lib/geometry/transformations/eye_plaques/COMS16mm
     :stop transformations:
 
     simulation source = Cs131_CS1_rev2
@@ -181,7 +181,7 @@
      #score energy deposition = yes
      output voxel info files  = yes
 
-    muen file = lib/muen/brachy_xcom_1.5MeV.muendat
+    muen file = $EGS_HOME/egs_brachy/lib/muen/brachy_xcom_1.5MeV.muendat
     muen for media = WATER_0.998
     dose scaling factor = 1.00 # For absolute dose # 
 	# scaling factor,dose/sk for I-6711=2.699551E+11 ,Pd103-200=1.556154E+09 ,Cs131-Isoray=2.6914205587E+09 , Sk is from the CLRPv2 TG43 database # This scaling factors are based on the data from CLRP Tg43v2 and CLRP_EPv2 databases
@@ -190,7 +190,7 @@
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 #   	Transport parameters	#
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-include file = lib/transport/low_energy_default
+include file = $EGS_HOME/egs_brachy/lib/transport/low_energy_default
 
 :start rng definition:
     type = ranmar


### PR DESCRIPTION
Prefix lib/ file references with $EGS_HOME/egs_brachy/ so distributed .egsinp files run from any working directory, remove obsolete batch-path comments, and reword comments that were picked up by the Included files egslog listing.